### PR TITLE
Fix incorrect property names in error messages

### DIFF
--- a/src/MiniValidation/MiniValidator.cs
+++ b/src/MiniValidation/MiniValidator.cs
@@ -92,6 +92,7 @@ namespace MiniValidation
                 if (property.HasValidationAttributes)
                 {
                     validationContext.MemberName = property.Name;
+                    validationContext.DisplayName = property.DisplayName;
                     validationResults ??= new();
                     var propertyValue = property.GetValue(target);
                     var propertyIsValid = Validator.TryValidateValue(propertyValue!, validationContext, validationResults, property.ValidationAttributes);
@@ -169,7 +170,10 @@ namespace MiniValidation
                 var index = 0;
                 foreach (var item in items)
                 {
-                    if (item is null) continue;
+                    if (item is null)
+                    {
+                        continue;
+                    }
 
                     var itemPrefix = $"{prefix}[{index}].";
 

--- a/src/MiniValidation/TypeDetailsCache.cs
+++ b/src/MiniValidation/TypeDetailsCache.cs
@@ -65,8 +65,9 @@ namespace MiniValidation
                 // We'll remove them at the end if any other validatable properties are present.
                 if (type == property.PropertyType && !hasSkipRecursionOnProperty)
                 {
+                    var displayName = property.GetCustomAttribute<DisplayAttribute>()?.Name ?? property.Name;
                     propertiesToValidate ??= new List<PropertyDetails>();
-                    propertiesToValidate.Add(new (property.Name, property.PropertyType, PropertyHelper.MakeNullSafeFastPropertyGetter(property), validationAttributes.ToArray(), true, enumerableType));
+                    propertiesToValidate.Add(new(property.Name, displayName, property.PropertyType, PropertyHelper.MakeNullSafeFastPropertyGetter(property), validationAttributes.ToArray(), true, enumerableType));
                     hasPropertiesOfOwnType = true;
                     continue;
                 }
@@ -80,8 +81,9 @@ namespace MiniValidation
 
                 if (recurse || hasValidationOnProperty)
                 {
+                    var displayName = property.GetCustomAttribute<DisplayAttribute>()?.Name ?? property.Name;
                     propertiesToValidate ??= new List<PropertyDetails>();
-                    propertiesToValidate.Add(new(property.Name, property.PropertyType, PropertyHelper.MakeNullSafeFastPropertyGetter(property), validationAttributes.ToArray(), recurse, enumerableTypeHasProperties ? enumerableType : null));
+                    propertiesToValidate.Add(new(property.Name, displayName, property.PropertyType, PropertyHelper.MakeNullSafeFastPropertyGetter(property), validationAttributes.ToArray(), recurse, enumerableTypeHasProperties ? enumerableType : null));
                     hasValidatableProperties = true;
                 }
             }
@@ -89,7 +91,7 @@ namespace MiniValidation
             if (hasPropertiesOfOwnType && propertiesToValidate != null)
             {
                 // Remove properties of same type if there's nothing to validate on them
-                for (int i = propertiesToValidate.Count - 1; i >= 0; i--)
+                for (var i = propertiesToValidate.Count - 1; i >= 0; i--)
                 {
                     var property = propertiesToValidate[i];
                     var enumerableTypeHasProperties = property.EnumerableType != null
@@ -113,7 +115,7 @@ namespace MiniValidation
                 return type.GetGenericArguments()[0];
             }
 
-            foreach (Type intType in type.GetInterfaces())
+            foreach (var intType in type.GetInterfaces())
             {
                 if (intType.IsGenericType
                     && intType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
@@ -126,7 +128,7 @@ namespace MiniValidation
         }
     }
 
-    internal record PropertyDetails(string Name, Type Type, Func<object, object?> PropertyGetter, ValidationAttribute[] ValidationAttributes, bool Recurse, Type? EnumerableType)
+    internal record PropertyDetails(string Name, string DisplayName, Type Type, Func<object, object?> PropertyGetter, ValidationAttribute[] ValidationAttributes, bool Recurse, Type? EnumerableType)
     {
         public object? GetValue(object target) => PropertyGetter(target);
         public bool IsEnumerable => EnumerableType != null;

--- a/src/MiniValidation/TypeDetailsCache.cs
+++ b/src/MiniValidation/TypeDetailsCache.cs
@@ -108,16 +108,20 @@ namespace MiniValidation
 
             static string GetDisplayName(PropertyInfo property)
             {
+                string? displayName = null;
+
                 var displayAttribute = property.GetCustomAttribute<DisplayAttribute>();
                 if (displayAttribute?.ResourceType == null)
                 {
-                    return displayAttribute?.Name ?? property.Name;
+                    displayName = displayAttribute?.Name;
                 }
                 else
                 {
                     var resourceManager = new ResourceManager(displayAttribute.ResourceType);
-                    return resourceManager.GetString(displayAttribute.Name);
+                    displayName = resourceManager.GetString(displayAttribute.Name!) ?? displayAttribute.Name;
                 }
+
+                return displayName ?? property.Name;
             }
         }
 


### PR DESCRIPTION
The current version of `MiniValidation` use incorrect names for properties in error messages. It shows always the name of the first property that has failed.

For example, giving this model and the corresponding endpoint:

```
public class Person
{
    [Required]
    [MaxLength(30)]
    public string FirstName { get; set; }

    [Required]
    [MaxLength(30)]
    public string LastName { get; set; }

    [EmailAddress]
    public string Email { get; set; }
}

app.MapPost("/people", (Person person) =>
{
    if (!MiniValidator.TryValidate(person, out var errors))
    {
        return Results.ValidationProblem(errors);
    }

    return Results.NoContent();
});
```

If we execute the following call:

```
curl -X 'POST' \
  'https://localhost:7052/people' \
  -H 'accept: */*' \
  -H 'Content-Type: application/json' \
  -d '{
  "firstName": "name",
  "email": "userexample.com"
}'
```

We get the following response:

```
{
  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
  "title": "One or more validation errors occurred.",
  "status": 400,
  "errors": {
    "LastName": [
      "The LastName field is required."
    ],
    "Email": [
      "The LastName field is not a valid e-mail address."
    ]
  }
}
```

The validation error message about the `Email` field specifies the incorrect property name.

This PR fixes the issue and adds also the support for the `Display` Data Annotation (including localized display names).