### PR TITLE
Move GetDisplayName out of cache to support localization

### DIFF
--- a/src/MiniValidation/MiniValidator.cs
+++ b/src/MiniValidation/MiniValidator.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Resources;
 using System.Runtime.CompilerServices;
 
 namespace MiniValidation
@@ -92,7 +93,7 @@ namespace MiniValidation
                 if (property.HasValidationAttributes)
                 {
                     validationContext.MemberName = property.Name;
-                    validationContext.DisplayName = property.DisplayName;
+                    validationContext.DisplayName = GetDisplayName(property);
                     validationResults ??= new();
                     var propertyValue = property.GetValue(target);
                     var propertyIsValid = Validator.TryValidateValue(propertyValue!, validationContext, validationResults, property.ValidationAttributes);
@@ -152,6 +153,23 @@ namespace MiniValidation
             validatedObjects[target] = isValid;
 
             return isValid;
+
+            static string GetDisplayName(PropertyDetails property)
+            {
+                string? displayName = null;
+
+                if (property.DisplayAttribute?.ResourceType == null)
+                {
+                    displayName = property.DisplayAttribute?.Name;
+                }
+                else
+                {
+                    var resourceManager = new ResourceManager(property.DisplayAttribute.ResourceType);
+                    displayName = resourceManager.GetString(property.DisplayAttribute.Name!) ?? property.DisplayAttribute.Name;
+                }
+
+                return displayName ?? property.Name;
+            }
         }
 
         private static bool TryValidateEnumerable(

--- a/src/MiniValidation/TypeDetailsCache.cs
+++ b/src/MiniValidation/TypeDetailsCache.cs
@@ -66,7 +66,6 @@ namespace MiniValidation
                 // We'll remove them at the end if any other validatable properties are present.
                 if (type == property.PropertyType && !hasSkipRecursionOnProperty)
                 {
-                    var displayName = property.GetCustomAttribute<DisplayAttribute>()?.Name ?? property.Name;
                     propertiesToValidate ??= new List<PropertyDetails>();
                     propertiesToValidate.Add(new(property.Name, GetDisplayName(property), property.PropertyType, PropertyHelper.MakeNullSafeFastPropertyGetter(property), validationAttributes.ToArray(), true, enumerableType));
                     hasPropertiesOfOwnType = true;
@@ -82,7 +81,6 @@ namespace MiniValidation
 
                 if (recurse || hasValidationOnProperty)
                 {
-                    var displayName = property.GetCustomAttribute<DisplayAttribute>()?.Name ?? property.Name;
                     propertiesToValidate ??= new List<PropertyDetails>();
                     propertiesToValidate.Add(new(property.Name, GetDisplayName(property), property.PropertyType, PropertyHelper.MakeNullSafeFastPropertyGetter(property), validationAttributes.ToArray(), recurse, enumerableTypeHasProperties ? enumerableType : null));
                     hasValidatableProperties = true;

--- a/src/MiniValidation/TypeDetailsCache.cs
+++ b/src/MiniValidation/TypeDetailsCache.cs
@@ -66,6 +66,7 @@ namespace MiniValidation
                 // We'll remove them at the end if any other validatable properties are present.
                 if (type == property.PropertyType && !hasSkipRecursionOnProperty)
                 {
+                    var displayName = property.GetCustomAttribute<DisplayAttribute>()?.Name ?? property.Name;
                     propertiesToValidate ??= new List<PropertyDetails>();
                     propertiesToValidate.Add(new(property.Name, GetDisplayName(property), property.PropertyType, PropertyHelper.MakeNullSafeFastPropertyGetter(property), validationAttributes.ToArray(), true, enumerableType));
                     hasPropertiesOfOwnType = true;
@@ -81,6 +82,7 @@ namespace MiniValidation
 
                 if (recurse || hasValidationOnProperty)
                 {
+                    var displayName = property.GetCustomAttribute<DisplayAttribute>()?.Name ?? property.Name;
                     propertiesToValidate ??= new List<PropertyDetails>();
                     propertiesToValidate.Add(new(property.Name, GetDisplayName(property), property.PropertyType, PropertyHelper.MakeNullSafeFastPropertyGetter(property), validationAttributes.ToArray(), recurse, enumerableTypeHasProperties ? enumerableType : null));
                     hasValidatableProperties = true;


### PR DESCRIPTION
The current implementation of the **GetDisplayName** method in [src/MiniValidation/TypeDetailsCache.cs](https://github.com/DamianEdwards/MiniValidation/blob/main/src/MiniValidation/TypeDetailsCache.cs#L109) puts the display name inside the cache. This is an issue because, if we make requests with different culture, the **ResourceManager** isn't used anymore and so we always get the localized display name corresponding to the language of the first request.

This PR moves **GetDisplayName** out of  **TypeDetailsCache.cs**, so the the display name is retrieved for every request, solving the localization problem.