### PR TITLE
Add support for IValidatableObject & polymorphic properties

### DIFF
--- a/MiniValidation.sln
+++ b/MiniValidation.sln
@@ -32,6 +32,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
 		global.json = global.json
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global

--- a/README.md
+++ b/README.md
@@ -43,12 +43,20 @@ else
     Console.WriteLine($"{nameof(Widget)} '{widget}' is valid!");
 }
 
-class Widget
+class Widget : IValidatableObject
 {
     [Required, MinLength(3)]
     public string Name { get; set; }
 
     public override string ToString() => Name;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (string.Equals(Name, "Widget", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return new("Cannot name a widget 'Widget'.", new [] { nameof(Name) });
+        }
+    }
 }
 ```
 ``` console
@@ -61,6 +69,11 @@ Name:
 Widget has errors!
   Name:
   - The field Name must be a string or array type with a minimum length of '3'.
+
+❯ widget.exe Widget
+Widget has errors!
+Name:
+  - Cannot name a widget 'Widget'.
 
 ❯ widget.exe MiniValidation
 Widget 'MiniValidation' is valid!
@@ -92,11 +105,19 @@ app.MapPost("/widgets", (Widget widget) =>
 
 app.Run();
 
-class Widget
+class Widget : IValidatableObject
 {
     [Required, MinLength(3)]
     public string? Name { get; set; }
 
     public override string? ToString() => Name;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (string.Equals(Name, "Widget", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return new("Cannot name a widget 'Widget'.");
+        }
+    }
 }
 ```

--- a/samples/Samples.Console/Program.cs
+++ b/samples/Samples.Console/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using MiniValidation;
 
@@ -22,10 +23,18 @@ else
     Console.WriteLine($"{nameof(Widget)} '{widget}' is valid!");
 }
 
-class Widget
+class Widget : IValidatableObject
 {
     [Required, MinLength(3)]
     public string Name { get; set; }
 
     public override string ToString() => Name;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (string.Equals(Name, "Widget", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return new("Cannot name a widget 'Widget'.");
+        }
+    }
 }

--- a/samples/Samples.Console/Program.cs
+++ b/samples/Samples.Console/Program.cs
@@ -34,7 +34,7 @@ class Widget : IValidatableObject
     {
         if (string.Equals(Name, "Widget", StringComparison.OrdinalIgnoreCase))
         {
-            yield return new("Cannot name a widget 'Widget'.");
+            yield return new("Cannot name a widget 'Widget'.", new [] { nameof(Name) });
         }
     }
 }

--- a/samples/Samples.Web/Program.cs
+++ b/samples/Samples.Web/Program.cs
@@ -22,10 +22,18 @@ app.MapPost("/widgets", (Widget widget) =>
 
 app.Run();
 
-class Widget
+class Widget : IValidatableObject
 {
     [Required, MinLength(3)]
     public string? Name { get; set; }
 
     public override string? ToString() => Name;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (string.Equals(Name, "Widget", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return new("Cannot name a widget 'Widget'.");
+        }
+    }
 }

--- a/samples/Samples.Web/Program.cs
+++ b/samples/Samples.Web/Program.cs
@@ -33,7 +33,7 @@ class Widget : IValidatableObject
     {
         if (string.Equals(Name, "Widget", StringComparison.OrdinalIgnoreCase))
         {
-            yield return new("Cannot name a widget 'Widget'.");
+            yield return new($"Cannot name a widget '{Name}'.", new[] { nameof(Name) });
         }
     }
 }

--- a/src/MiniValidation/MiniValidator.cs
+++ b/src/MiniValidation/MiniValidator.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Resources;
 using System.Runtime.CompilerServices;
 
@@ -53,8 +54,10 @@ namespace MiniValidation
             }
 
             var validatedObjects = new Dictionary<object, bool?>();
-            errors = new Dictionary<string, string[]>();
-            var isValid = TryValidateImpl(target, recurse, errors, validatedObjects);
+            var workingErrors = new Dictionary<string, List<string>>();
+            var isValid = TryValidateImpl(target, recurse, workingErrors, validatedObjects);
+
+            errors = MapToFinalErrorsResult(workingErrors);
 
             return isValid;
         }
@@ -62,7 +65,7 @@ namespace MiniValidation
         private static bool TryValidateImpl(
             object target,
             bool recurse,
-            IDictionary<string, string[]> errors,
+            Dictionary<string, List<string>> workingErrors,
             Dictionary<object, bool?> validatedObjects,
             List<ValidationResult>? validationResults = null,
             string? prefix = null,
@@ -84,22 +87,21 @@ namespace MiniValidation
             var typeProperties = _typeDetailsCache.Get(targetType);
 
             var isValid = true;
-
             var propertiesToRecurse = recurse ? new List<PropertyDetails>() : null;
-            ValidationContext validationContext = new(target);
+            ValidationContext propsValidationContext = new(target);
 
             foreach (var property in typeProperties)
             {
                 if (property.HasValidationAttributes)
                 {
-                    validationContext.MemberName = property.Name;
-                    validationContext.DisplayName = GetDisplayName(property);
+                    propsValidationContext.MemberName = property.Name;
+                    propsValidationContext.DisplayName = GetDisplayName(property);
                     validationResults ??= new();
                     var propertyValue = property.GetValue(target);
-                    var propertyIsValid = Validator.TryValidateValue(propertyValue!, validationContext, validationResults, property.ValidationAttributes);
+                    var propertyIsValid = Validator.TryValidateValue(propertyValue!, propsValidationContext, validationResults, property.ValidationAttributes);
                     if (!propertyIsValid)
                     {
-                        ProcessValidationResults(property.Name, validationResults, errors, prefix);
+                        ProcessValidationResults(property.Name, validationResults, workingErrors, prefix);
                         isValid = false;
                     }
                 }
@@ -109,13 +111,25 @@ namespace MiniValidation
                 }
             }
 
+            if (typeof(IValidatableObject).IsAssignableFrom(targetType))
+            {
+                var validatable = (IValidatableObject)target;
+                ValidationContext validatableValidationContext = new(target);
+                var validatableResults = validatable.Validate(validatableValidationContext);
+                if (validatableResults is { })
+                {
+                    ProcessValidationResults(validatableResults, workingErrors, prefix);
+                    isValid = workingErrors.Count == 0;
+                }
+            }
+
             if (isValid && recurse && currentDepth <= MaxDepth)
             {
                 // Validate IEnumerable
                 if (target is IEnumerable)
                 {
                     RuntimeHelpers.EnsureSufficientExecutionStack();
-                    isValid = TryValidateEnumerable(target, recurse, errors, validatedObjects, validationResults, prefix, currentDepth);
+                    isValid = TryValidateEnumerable(target, recurse, workingErrors, validatedObjects, validationResults, prefix, currentDepth);
                 }
 
                 // Validate complex properties
@@ -132,12 +146,12 @@ namespace MiniValidation
                             if (property.IsEnumerable)
                             {
                                 var thePrefix = $"{prefix}{property.Name}";
-                                isValid = TryValidateEnumerable(propertyValue, recurse, errors, validatedObjects, validationResults, thePrefix, currentDepth);
+                                isValid = TryValidateEnumerable(propertyValue, recurse, workingErrors, validatedObjects, validationResults, thePrefix, currentDepth);
                             }
                             else
                             {
                                 var thePrefix = $"{prefix}{property.Name}."; // <-- Note trailing '.' here
-                                isValid = TryValidateImpl(propertyValue, recurse, errors, validatedObjects, validationResults, thePrefix, currentDepth + 1);
+                                isValid = TryValidateImpl(propertyValue, recurse, workingErrors, validatedObjects, validationResults, thePrefix, currentDepth + 1);
                             }
                         }
 
@@ -150,7 +164,7 @@ namespace MiniValidation
             }
 
             // Update state of target in tracking dictionary
-            validatedObjects[target] = isValid;
+            validatedObjects[target] = isValid;  
 
             return isValid;
 
@@ -175,7 +189,7 @@ namespace MiniValidation
         private static bool TryValidateEnumerable(
             object target,
             bool recurse,
-            IDictionary<string, string[]> errors,
+            Dictionary<string, List<string>> workingErrors,
             Dictionary<object, bool?> validatedObjects,
             List<ValidationResult>? validationResults,
             string? prefix = null,
@@ -195,7 +209,7 @@ namespace MiniValidation
 
                     var itemPrefix = $"{prefix}[{index}].";
 
-                    isValid = TryValidateImpl(item, recurse, errors, validatedObjects, validationResults, prefix: itemPrefix, currentDepth + 1);
+                    isValid = TryValidateImpl(item, recurse, workingErrors, validatedObjects, validationResults, prefix: itemPrefix, currentDepth + 1);
 
                     if (!isValid)
                     {
@@ -207,20 +221,54 @@ namespace MiniValidation
             return isValid;
         }
 
-        private static void ProcessValidationResults(string propertyName, ICollection<ValidationResult> validationResults, IDictionary<string, string[]> errors, string? prefix)
+        private static IDictionary<string, string[]> MapToFinalErrorsResult(Dictionary<string, List<string>> workingErrors)
+        {
+            var result = new Dictionary<string, string[]>(workingErrors.Count);
+
+            foreach (var fieldError in workingErrors)
+            {
+                if (!result.ContainsKey(fieldError.Key))
+                {
+                    result.Add(fieldError.Key, fieldError.Value.ToArray());
+                }
+                else
+                {
+                    var existingFieldErrors = result[fieldError.Key];
+                    result[fieldError.Key] = existingFieldErrors.Concat(fieldError.Value).ToArray();
+                }
+            }
+
+            return result;
+        }
+
+        private static void ProcessValidationResults(IEnumerable<ValidationResult> validationResults, Dictionary<string, List<string>> errors, string? prefix)
+        {
+            foreach (var result in validationResults)
+            {
+                foreach (var memberName in result.MemberNames)
+                {
+                    var key = $"{prefix}{memberName}";
+                    if (!errors.ContainsKey(key))
+                    {
+                        errors.Add(key, new());
+                    }
+                    errors[key].Add(result.ErrorMessage ?? "");
+                }
+            }
+        }
+
+        private static void ProcessValidationResults(string propertyName, ICollection<ValidationResult> validationResults, Dictionary<string, List<string>> errors, string? prefix)
         {
             if (validationResults.Count == 0)
             {
                 return;
             }
 
-            var errorsList = new string[validationResults.Count];
-            var i = 0;
+            var errorsList = new List<string>(validationResults.Count);
 
             foreach (var result in validationResults)
             {
-                errorsList[i] = result.ErrorMessage ?? "";
-                i++;
+                errorsList.Add(result.ErrorMessage ?? "");
             }
 
             errors.Add($"{prefix}{propertyName}", errorsList);

--- a/src/MiniValidation/TypeDetailsCache.cs
+++ b/src/MiniValidation/TypeDetailsCache.cs
@@ -12,8 +12,13 @@ namespace MiniValidation
         private static readonly PropertyDetails[] _emptyPropertyDetails = Array.Empty<PropertyDetails>();
         private readonly ConcurrentDictionary<Type, PropertyDetails[]> _cache = new();
 
-        public PropertyDetails[] Get(Type type)
+        public PropertyDetails[] Get(Type? type)
         {
+            if (type is null)
+            {
+                return _emptyPropertyDetails;
+            }
+
             if (!_cache.ContainsKey(type))
             {
                 Visit(type);
@@ -44,7 +49,7 @@ namespace MiniValidation
             var hasPropertiesOfOwnType = false;
             var hasValidatableProperties = false;
 
-            foreach (var property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            foreach (var property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy))
             {
                 if (property.GetIndexParameters().Length > 0)
                 {
@@ -73,11 +78,14 @@ namespace MiniValidation
 
                 Visit(property.PropertyType, visited);
                 var propertyTypeHasProperties = _cache.TryGetValue(property.PropertyType, out var properties) && properties.Length > 0;
-                var propertyTypeIsValidatbleObject = typeof(IValidatableObject).IsAssignableFrom(property.PropertyType);
+                var propertyTypeIsValidatableObject = typeof(IValidatableObject).IsAssignableFrom(property.PropertyType);
+                var propertyTypeSupportsPolymorphism = !property.PropertyType.IsSealed;
                 var enumerableTypeHasProperties = enumerableType != null
                     && _cache.TryGetValue(enumerableType, out var enumProperties)
                     && enumProperties.Length > 0;
-                var recurse = (enumerableTypeHasProperties || propertyTypeHasProperties || propertyTypeIsValidatbleObject) && !hasSkipRecursionOnProperty;
+                var recurse = (enumerableTypeHasProperties || propertyTypeHasProperties || propertyTypeIsValidatableObject
+                    || propertyTypeSupportsPolymorphism)
+                    && !hasSkipRecursionOnProperty;
 
                 if (recurse || hasValidationOnProperty)
                 {

--- a/src/MiniValidation/TypeDetailsCache.cs
+++ b/src/MiniValidation/TypeDetailsCache.cs
@@ -73,10 +73,11 @@ namespace MiniValidation
 
                 Visit(property.PropertyType, visited);
                 var propertyTypeHasProperties = _cache.TryGetValue(property.PropertyType, out var properties) && properties.Length > 0;
+                var propertyTypeIsValidatbleObject = typeof(IValidatableObject).IsAssignableFrom(property.PropertyType);
                 var enumerableTypeHasProperties = enumerableType != null
                     && _cache.TryGetValue(enumerableType, out var enumProperties)
                     && enumProperties.Length > 0;
-                var recurse = (enumerableTypeHasProperties || propertyTypeHasProperties) && !hasSkipRecursionOnProperty;
+                var recurse = (enumerableTypeHasProperties || propertyTypeHasProperties || propertyTypeIsValidatbleObject) && !hasSkipRecursionOnProperty;
 
                 if (recurse || hasValidationOnProperty)
                 {

--- a/tests/MiniValidation.UnitTests/Recursion.cs
+++ b/tests/MiniValidation.UnitTests/Recursion.cs
@@ -274,6 +274,36 @@ public class Recursion
     }
 
     [Fact]
+    public void Invalid_When_Derived_ValidatableObject_Child_Validate_Is_Invalid()
+    {
+        var thingToValidate = new TestValidatableType
+        {
+            Child = new TestValidatableChildType { TwentyOrMore = 19 }
+        };
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Equal(1, errors.Count);
+        Assert.Equal($"{nameof(TestValidatableType.Child)}.{nameof(TestValidatableType.TwentyOrMore)}", errors.Keys.First());
+    }
+
+    [Fact]
+    public void Invalid_When_Derived_Polymorphic_Child_Validate_Is_Invalid()
+    {
+        var thingToValidate = new TestValidatableType
+        {
+            Child = new TestValidatableChildType { MinLengthFive = "123" }
+        };
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Equal(1, errors.Count);
+        Assert.Equal($"{nameof(TestValidatableType.Child)}.{nameof(TestValidatableChildType.MinLengthFive)}", errors.Keys.First());
+    }
+
+    [Fact]
     public void Child_ValidatableObject_Is_Not_Validated_When_Parent_Is_Invalid()
     {
         var thingToValidate = new TestValidatableType { TenOrMore = 9 };
@@ -284,5 +314,50 @@ public class Recursion
         Assert.False(result);
         Assert.Equal(1, errors.Count);
         Assert.Equal($"{nameof(TestValidatableType.TenOrMore)}", errors.Keys.First());
+    }
+
+    [Fact]
+    public void Invalid_When_Derived_ValidatableOnlyChild_Is_Invalid()
+    {
+        var thingToValidate = new TestValidatableType
+        {
+            ValidatableOnlyChild = new TestValidatableOnlyType { TwentyOrMore = 12 }
+        };
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Equal(1, errors.Count);
+        Assert.Equal($"{nameof(TestValidatableType.ValidatableOnlyChild)}.{nameof(TestValidatableOnlyType.TwentyOrMore)}", errors.Keys.First());
+    }
+
+    [Fact]
+    public void Invalid_When_Polymorphic_ValidatableOnlyChild_Is_Invalid()
+    {
+        var thingToValidate = new TestValidatableType
+        {
+            PocoChild = new TestValidatableOnlyType { TwentyOrMore = 12 }
+        };
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Equal(1, errors.Count);
+        Assert.Equal($"{nameof(TestValidatableType.PocoChild)}.{nameof(TestValidatableOnlyType.TwentyOrMore)}", errors.Keys.First());
+    }
+
+    [Fact]
+    public void Invalid_When_Polymorphic_Child_With_Validation_Attributes_Is_Invalid()
+    {
+        var thingToValidate = new TestValidatableType
+        {
+            PocoChild = new TestChildType { MinLengthFive = "123" }
+        };
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Equal(1, errors.Count);
+        Assert.Equal($"{nameof(TestValidatableType.PocoChild)}.{nameof(TestChildType.MinLengthFive)}", errors.Keys.First());
     }
 }

--- a/tests/MiniValidation.UnitTests/Recursion.cs
+++ b/tests/MiniValidation.UnitTests/Recursion.cs
@@ -257,4 +257,32 @@ public class Recursion
         Assert.True(result);
         Assert.Equal(0, errors.Count);
     }
+
+    [Fact]
+    public void Invalid_When_ValidatableObject_Child_Validate_Is_Invalid()
+    {
+        var thingToValidate = new TestValidatableType
+        {
+            ValidatableChild = new TestValidatableChildType { TwentyOrMore = 12 }
+        };
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Equal(1, errors.Count);
+        Assert.Equal($"{nameof(TestValidatableType.ValidatableChild)}.{nameof(TestValidatableType.TwentyOrMore)}", errors.Keys.First());
+    }
+
+    [Fact]
+    public void Child_ValidatableObject_Is_Not_Validated_When_Parent_Is_Invalid()
+    {
+        var thingToValidate = new TestValidatableType { TenOrMore = 9 };
+        thingToValidate.ValidatableChild = new TestValidatableChildType { TwentyOrMore = 12 };
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Equal(1, errors.Count);
+        Assert.Equal($"{nameof(TestValidatableType.TenOrMore)}", errors.Keys.First());
+    }
 }

--- a/tests/MiniValidation.UnitTests/TestTypes.cs
+++ b/tests/MiniValidation.UnitTests/TestTypes.cs
@@ -9,12 +9,29 @@ class TestType
     public int TenOrMore { get; set; } = 10;
 
     [Required]
-    public TestChildType Child { get; set; } = new TestChildType();
+    public virtual TestChildType Child { get; set; } = new TestChildType();
+
+    public virtual TestValidatableChildType ValidatableChild { get; set; } = new TestValidatableChildType();
 
     [SkipRecursion]
     public TestChildType SkippedChild { get; set; } = new TestChildType();
 
     public IList<TestChildType> Children { get; } = new List<TestChildType>();
+}
+
+class TestValidatableType : TestType, IValidatableObject
+{
+    public int TwentyOrMore { get; set; } = 20;
+
+    public override TestChildType Child { get; set; } = new TestChildTypeDerivative();
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (TwentyOrMore < 20)
+        {
+            yield return new ValidationResult($"The field {validationContext.DisplayName} must have a value greater than 20.", new[] { nameof(TwentyOrMore) });
+        }
+    }
 }
 
 class TestChildType
@@ -43,6 +60,19 @@ class TestChildType
             {
                 target.Child.RequiredCategory = null;
             }
+        }
+    }
+}
+
+class TestValidatableChildType : IValidatableObject
+{
+    public int TwentyOrMore { get; set; } = 20;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (TwentyOrMore < 20)
+        {
+            yield return new ValidationResult($"The field {validationContext.DisplayName} must have a value greater than 20.", new[] { nameof(TwentyOrMore) });
         }
     }
 }

--- a/tests/MiniValidation.UnitTests/TestTypes.cs
+++ b/tests/MiniValidation.UnitTests/TestTypes.cs
@@ -13,6 +13,10 @@ class TestType
 
     public virtual TestValidatableChildType ValidatableChild { get; set; } = new TestValidatableChildType();
 
+    public virtual TestValidatableOnlyType ValidatableOnlyChild { get; set; } = new TestValidatableOnlyType();
+
+    public virtual object? PocoChild { get; set; } = default;
+
     [SkipRecursion]
     public TestChildType SkippedChild { get; set; } = new TestChildType();
 
@@ -30,6 +34,32 @@ class TestValidatableType : TestType, IValidatableObject
         if (TwentyOrMore < 20)
         {
             yield return new ValidationResult($"The field {validationContext.DisplayName} must have a value greater than 20.", new[] { nameof(TwentyOrMore) });
+        }
+    }
+}
+
+class TestValidatableOnlyType : IValidatableObject
+{
+    public int TwentyOrMore { get; set; } = 20;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (TwentyOrMore < 20)
+        {
+            yield return new ValidationResult($"The field {validationContext.DisplayName} must have a value greater than 20.", new[] { nameof(TwentyOrMore) });
+        }
+    }
+}
+
+class TestClassLevelValidatableOnlyType : IValidatableObject
+{
+    public int TwentyOrMore { get; set; } = 20;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (TwentyOrMore < 20)
+        {
+            yield return new ValidationResult($"The field {validationContext.DisplayName} must have a value greater than 20.");
         }
     }
 }
@@ -64,7 +94,7 @@ class TestChildType
     }
 }
 
-class TestValidatableChildType : IValidatableObject
+class TestValidatableChildType : TestChildType, IValidatableObject
 {
     public int TwentyOrMore { get; set; } = 20;
 

--- a/tests/MiniValidation.UnitTests/TryValidate.cs
+++ b/tests/MiniValidation.UnitTests/TryValidate.cs
@@ -205,7 +205,7 @@ public class TryValidate
     }
 
     [Fact]
-    public void Invalid_When_ValidatableObject_Is_Invalid_And_Has_Invalid_Attributes()
+    public void ValidatableObject_Is_Not_Validated_When_Has_Invalid_Attributes()
     {
         var thingToValidate = new TestValidatableType
         {
@@ -216,8 +216,22 @@ public class TryValidate
         var result = MiniValidator.TryValidate(thingToValidate, out var errors);
 
         Assert.False(result);
-        Assert.Equal(2, errors.Count);
+        Assert.Equal(1, errors.Count);
         Assert.Equal(nameof(TestValidatableType.TenOrMore), errors.Keys.First());
-        Assert.Equal(nameof(TestValidatableType.TwentyOrMore), errors.Keys.Skip(1).First());
+    }
+
+    [Fact]
+    public void Invalid_When_ValidatableObject_With_Class_Level_Only_Is_Invalid()
+    {
+        var thingToValidate = new TestClassLevelValidatableOnlyType
+        {
+            TwentyOrMore = 12
+        };
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Equal(1, errors.Count);
+        Assert.Equal("", errors.Keys.First());
     }
 }

--- a/tests/MiniValidation.UnitTests/TryValidate.cs
+++ b/tests/MiniValidation.UnitTests/TryValidate.cs
@@ -173,4 +173,51 @@ public class TryValidate
         Assert.False(result);
         Assert.Equal(1, errors.Count);
     }
+
+    [Fact]
+    public void Invalid_When_ValidatableObject_Validate_Is_Invalid()
+    {
+        var thingToValidate = new TestValidatableType
+        {
+            TwentyOrMore = 12
+        };
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Equal(1, errors.Count);
+        Assert.Equal(nameof(TestValidatableType.TwentyOrMore), errors.Keys.First());
+    }
+
+    [Fact]
+    public void Invalid_When_ValidatableObject_Has_Invalid_Attributes()
+    {
+        var thingToValidate = new TestValidatableType
+        {
+            TenOrMore = 9
+        };
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Equal(1, errors.Count);
+        Assert.Equal(nameof(TestValidatableType.TenOrMore), errors.Keys.First());
+    }
+
+    [Fact]
+    public void Invalid_When_ValidatableObject_Is_Invalid_And_Has_Invalid_Attributes()
+    {
+        var thingToValidate = new TestValidatableType
+        {
+            TenOrMore = 9,
+            TwentyOrMore = 12
+        };
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Equal(2, errors.Count);
+        Assert.Equal(nameof(TestValidatableType.TenOrMore), errors.Keys.First());
+        Assert.Equal(nameof(TestValidatableType.TwentyOrMore), errors.Keys.Skip(1).First());
+    }
 }


### PR DESCRIPTION
- Property values are always retrieved now to get correct runtime type for property value
- `TypeDetailsCache` preserves properties if they're not primitive and not sealed to allow for polymorphic values
- Get inherited properties when visiting types (`BindingFlags.FlattenHierarchy`)
- Fix issue with class-level errors (no field name) from `IValidatableObject`
- Refactored validation internals to not build the returned error list until all validation of an object is complete
- Fixed some Roslyn analyzer suggestions
- Updated samples
- Addresses #20