### PR TITLE
Support runtime property attributes via TypeDescriptor

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="PolySharp" Version="1.13.2" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.4.0" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>0.8.0</VersionPrefix>
+    <VersionPrefix>0.9.0</VersionPrefix>
     <!-- VersionSuffix used for local builds -->
     <VersionSuffix>dev</VersionSuffix>
     <!-- VersionSuffix to be used for CI builds -->

--- a/src/MiniValidation/MiniValidation.csproj
+++ b/src/MiniValidation/MiniValidation.csproj
@@ -15,6 +15,10 @@
   <ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="\" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/MiniValidation/TypeDetailsCache.cs
+++ b/src/MiniValidation/TypeDetailsCache.cs
@@ -202,7 +202,9 @@ internal class TypeDetailsCache
 
         if (TryGetAttributesViaTypeDescriptor(property, out var typeDescriptorAttributes))
         {
-            customAttributes = customAttributes.Concat(typeDescriptorAttributes.Cast<Attribute>());
+            customAttributes = customAttributes
+                .Concat(typeDescriptorAttributes.Cast<Attribute>())
+                .Distinct();
         }
 
         foreach (var attr in customAttributes)

--- a/src/MiniValidation/TypeDetailsCache.cs
+++ b/src/MiniValidation/TypeDetailsCache.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
@@ -201,7 +202,7 @@ internal class TypeDetailsCache
 
         if (TryGetAttributesViaTypeDescriptor(property, out var typeDescriptorAttributes))
         {
-            customAttributes = customAttributes.Concat(typeDescriptorAttributes!.Cast<Attribute>());
+            customAttributes = customAttributes.Concat(typeDescriptorAttributes.Cast<Attribute>());
         }
 
         foreach (var attr in customAttributes)
@@ -224,7 +225,7 @@ internal class TypeDetailsCache
         return new(validationAttributes?.ToArray(), displayAttribute, skipRecursionAttribute);
     }
 
-    private static bool TryGetAttributesViaTypeDescriptor(PropertyInfo property, out IEnumerable<Attribute>? typeDescriptorAttributes)
+    private static bool TryGetAttributesViaTypeDescriptor(PropertyInfo property, [NotNullWhen(true)] out IEnumerable<Attribute>? typeDescriptorAttributes)
     {
         var attributes = TypeDescriptor.GetProperties(property.ReflectedType!)
             .Cast<PropertyDescriptor>()

--- a/tests/MiniValidation.UnitTests/TestTypes.cs
+++ b/tests/MiniValidation.UnitTests/TestTypes.cs
@@ -238,3 +238,8 @@ class ClassWithUri
     [Required]
     public Uri? BaseAddress { get; set; }
 }
+
+class TestTypeForTypeDescriptor
+{
+    public string? PropertyToBeRequired { get; set; }
+}

--- a/tests/MiniValidation.UnitTests/TestTypes.cs
+++ b/tests/MiniValidation.UnitTests/TestTypes.cs
@@ -242,4 +242,7 @@ class ClassWithUri
 class TestTypeForTypeDescriptor
 {
     public string? PropertyToBeRequired { get; set; }
+
+    [MaxLength(1)]
+    public string? AnotherProperty { get; set; } = "Test";
 }

--- a/tests/MiniValidation.UnitTests/TryValidate.cs
+++ b/tests/MiniValidation.UnitTests/TryValidate.cs
@@ -408,6 +408,9 @@ public class TryValidate
         var (isValid, errors) = await MiniValidator.TryValidateAsync(thingToValidate);
 
         Assert.False(isValid);
-        Assert.Equal(1, errors.Count);
+        Assert.Equal(2, errors.Count);
+
+        Assert.Single(errors["PropertyToBeRequired"]);
+        Assert.Single(errors["AnotherProperty"]);
     }
 }

--- a/tests/MiniValidation.UnitTests/TryValidate.cs
+++ b/tests/MiniValidation.UnitTests/TryValidate.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace MiniValidation.UnitTests;
@@ -395,5 +394,20 @@ public class TryValidate
         Assert.False(isValid);
         Assert.Equal(1, errors.Count);
         Assert.Equal(nameof(IServiceProvider), errors.Keys.First());
+    }
+
+    [Fact]
+    public async Task TryValidateAsync_With_Attribute_Attached_Via_TypeDescriptor()
+    {
+        var thingToValidate = new TestTypeForTypeDescriptor();
+
+        TypeDescriptorExtensions.AttachAttribute<TestTypeForTypeDescriptor>(
+            nameof(TestTypeForTypeDescriptor.PropertyToBeRequired), 
+            _ => new RequiredAttribute());
+
+        var (isValid, errors) = await MiniValidator.TryValidateAsync(thingToValidate);
+
+        Assert.False(isValid);
+        Assert.Equal(1, errors.Count);
     }
 }

--- a/tests/MiniValidation.UnitTests/TryValidate.cs
+++ b/tests/MiniValidation.UnitTests/TryValidate.cs
@@ -401,7 +401,7 @@ public class TryValidate
     {
         var thingToValidate = new TestTypeForTypeDescriptor();
 
-        TypeDescriptorExtensions.AttachAttribute<TestTypeForTypeDescriptor>(
+        typeof(TestTypeForTypeDescriptor).AttachAttribute(
             nameof(TestTypeForTypeDescriptor.PropertyToBeRequired), 
             _ => new RequiredAttribute());
 

--- a/tests/MiniValidation.UnitTests/TypeDescriptorExtensions.cs
+++ b/tests/MiniValidation.UnitTests/TypeDescriptorExtensions.cs
@@ -10,7 +10,7 @@ namespace MiniValidation.UnitTests
 
             foreach (PropertyDescriptor pd in TypeDescriptor.GetProperties(type))
             {
-                if (pd.Name.EndsWith(propertyName))
+                if (pd.Name == propertyName)
                 {
                     var pdWithAttribute = TypeDescriptor.CreateProperty(
                         type,

--- a/tests/MiniValidation.UnitTests/TypeDescriptorExtensions.cs
+++ b/tests/MiniValidation.UnitTests/TypeDescriptorExtensions.cs
@@ -4,10 +4,8 @@ namespace MiniValidation.UnitTests
 {
     internal static class TypeDescriptorExtensions
     {
-        public static void AttachAttribute<T>(string propertyName, Func<PropertyDescriptor, Attribute> attributeFactory)
+        public static void AttachAttribute(this Type type, string propertyName, Func<PropertyDescriptor, Attribute> attributeFactory)
         {
-            var type = typeof(T);
-
             var ctd = new PropertyOverridingTypeDescriptor(TypeDescriptor.GetProvider(type).GetTypeDescriptor(type)!);
 
             foreach (PropertyDescriptor pd in TypeDescriptor.GetProperties(type))

--- a/tests/MiniValidation.UnitTests/TypeDescriptorUtils.cs
+++ b/tests/MiniValidation.UnitTests/TypeDescriptorUtils.cs
@@ -1,0 +1,102 @@
+﻿using System.ComponentModel;
+
+namespace MiniValidation.UnitTests
+{
+    internal static class TypeDescriptorExtensions
+    {
+        public static void AttachAttribute<T>(string propertyName, Func<PropertyDescriptor, Attribute> attributeFactory)
+        {
+            var type = typeof(T);
+
+            var ctd = new PropertyOverridingTypeDescriptor(TypeDescriptor.GetProvider(type).GetTypeDescriptor(type)!);
+
+            foreach (PropertyDescriptor pd in TypeDescriptor.GetProperties(type))
+            {
+                if (pd.Name.EndsWith(propertyName))
+                {
+                    var pdWithAttribute = TypeDescriptor.CreateProperty(
+                        type,
+                        pd,
+                        attributeFactory(pd));
+
+                    ctd.OverrideProperty(pdWithAttribute);
+                }
+            }
+
+            TypeDescriptor.AddProvider(new TypeDescriptorOverridingProvider(ctd), type);
+        }
+    }
+
+    // From https://stackoverflow.com/questions/12143650/how-to-add-property-level-attribute-to-the-typedescriptor-at-runtime
+    internal class PropertyOverridingTypeDescriptor : CustomTypeDescriptor
+    {
+        private readonly Dictionary<string, PropertyDescriptor> overridePds = new Dictionary<string, PropertyDescriptor>();
+
+        public PropertyOverridingTypeDescriptor(ICustomTypeDescriptor parent)
+            : base(parent)
+        { }
+
+        public void OverrideProperty(PropertyDescriptor pd)
+        {
+            overridePds[pd.Name] = pd;
+        }
+
+        public override object? GetPropertyOwner(PropertyDescriptor? pd)
+        {
+            var propertyOwner = base.GetPropertyOwner(pd);
+
+            if (propertyOwner == null)
+            {
+                return this;
+            }
+
+            return propertyOwner;
+        }
+
+        public override PropertyDescriptorCollection GetProperties()
+        {
+            return GetPropertiesImpl(base.GetProperties());
+        }
+
+        public override PropertyDescriptorCollection GetProperties(Attribute[]? attributes)
+        {
+            return GetPropertiesImpl(base.GetProperties(attributes));
+        }
+
+        private PropertyDescriptorCollection GetPropertiesImpl(PropertyDescriptorCollection pdc)
+        {
+            var pdl = new List<PropertyDescriptor>(pdc.Count + 1);
+
+            foreach (PropertyDescriptor pd in pdc)
+            {
+                if (overridePds.ContainsKey(pd.Name))
+                {
+                    pdl.Add(overridePds[pd.Name]);
+                }
+                else
+                {
+                    pdl.Add(pd);
+                }
+            }
+
+            var ret = new PropertyDescriptorCollection(pdl.ToArray());
+
+            return ret;
+        }
+    }
+
+    internal class TypeDescriptorOverridingProvider : TypeDescriptionProvider
+    {
+        private readonly ICustomTypeDescriptor ctd;
+
+        public TypeDescriptorOverridingProvider(ICustomTypeDescriptor ctd)
+        {
+            this.ctd = ctd;
+        }
+
+        public override ICustomTypeDescriptor? GetTypeDescriptor(Type objectType, object? instance)
+        {
+            return ctd;
+        }
+    }
+}


### PR DESCRIPTION
This adds support for property attributes configured via `TypeDescriptor`.

The code for `PropertyOverridingTypeDescriptor` is taken from [StackOverflow](https://stackoverflow.com/questions/12143650/how-to-add-property-level-attribute-to-the-typedescriptor-at-runtime) as stated in the comment.

This should fix #52.