### PR TITLE
Add swallowing exception from property.GetValue(target) to prevent failing validation

### DIFF
--- a/src/MiniValidation/MiniValidator.cs
+++ b/src/MiniValidation/MiniValidator.cs
@@ -380,7 +380,8 @@ public static class MiniValidator
 
         foreach (var property in typeProperties)
         {
-            var propertyValue = property.GetValue(target);
+            if (!TryGetPropertyValue(target, property, out var propertyValue)) continue;
+
             var propertyValueType = propertyValue?.GetType();
             var (properties, _) = _typeDetailsCache.Get(propertyValueType);
 
@@ -492,6 +493,25 @@ public static class MiniValidator
         static string GetDisplayName(PropertyDetails property)
         {
             return property.DisplayAttribute?.GetName() ?? property.Name;
+        }
+    }
+
+    private static bool TryGetPropertyValue(
+        object target, 
+        PropertyDetails property, 
+        out object? propertyValue)
+    {
+        propertyValue = null;
+        
+        try
+        {
+            propertyValue = property.GetValue(target);
+            return true;
+        }
+        catch
+        {
+            // Exception ignored - we don't want to fail validation because of a property getter exception
+            return false;
         }
     }
 

--- a/tests/MiniValidation.UnitTests/TestTypes.cs
+++ b/tests/MiniValidation.UnitTests/TestTypes.cs
@@ -246,3 +246,10 @@ class TestTypeForTypeDescriptor
     [MaxLength(1)]
     public string? AnotherProperty { get; set; } = "Test";
 }
+
+class ClassWithNotImplementedProperty
+{
+    [Required]
+    public string? ValidProperty { get; set; } 
+    public TestTypeForTypeDescriptor NotImplementedProperty => throw new NotImplementedException();
+}

--- a/tests/MiniValidation.UnitTests/TryValidate.cs
+++ b/tests/MiniValidation.UnitTests/TryValidate.cs
@@ -413,4 +413,15 @@ public class TryValidate
         Assert.Single(errors["PropertyToBeRequired"]);
         Assert.Single(errors["AnotherProperty"]);
     }
+
+    [Fact]
+    public void Does_Not_Throw_Exception_When_TryValidate_Called_On_Target_With_Not_Implemented_Property()
+    {
+        var thingToValidate = new ClassWithNotImplementedProperty
+        {
+            ValidProperty = "valid value"
+        };
+
+    Assert.True(MiniValidator.TryValidate(thingToValidate, out _));
+    }
 }


### PR DESCRIPTION
### Context
Sometimes, we may have properties that are not yet implemented or can throw an exception during evaluation. Validating an instance in such a case will fail and throw this exception even though it's not the library's intention (ref.: https://github.com/Kraviecc/MiniValidation/blob/main/src/MiniValidation/MiniValidator.cs#L383). I strongly believe that validation should try to validate what can be validated and skip properties that throw an exception.

### Solution
I was thinking about a proper solution to the problem: I initially thought that we could move the aforementioned line of code later (after checking if the property has any validation attribute) and that getting the property's type could be taken from the property base type but I can see that in the current implementation it will take the _underlying_ type (which is desired; ref.: https://github.com/Kraviecc/MiniValidation/blob/main/src/MiniValidation/MiniValidator.cs#L384). So, I've ended up with the solution of swallowing any exception that can be raised during property value evaluation.

Please modify the code or let me know if there's a better approach.