### PR TITLE
Filter out props for validation

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>0.9.1</VersionPrefix>
+    <VersionPrefix>0.9.2</VersionPrefix>
     <!-- VersionSuffix used for local builds -->
     <VersionSuffix>dev</VersionSuffix>
     <!-- VersionSuffix to be used for CI builds -->

--- a/src/MiniValidation/MiniValidator.cs
+++ b/src/MiniValidation/MiniValidator.cs
@@ -391,7 +391,7 @@ public static class MiniValidator
         var propertiesToRecurse = recurse ? new Dictionary<PropertyDetails, object>() : null;
         var validationContext = new ValidationContext(target, serviceProvider: serviceProvider, items: null);
 
-        foreach (var property in typeProperties)
+        foreach (var property in typeProperties.Where(p => p.HasValidationAttributes || recurse))
         {
             var propertyValue = property.GetValue(target);
             var propertyValueType = propertyValue?.GetType();

--- a/src/MiniValidation/MiniValidator.cs
+++ b/src/MiniValidation/MiniValidator.cs
@@ -391,8 +391,14 @@ public static class MiniValidator
         var propertiesToRecurse = recurse ? new Dictionary<PropertyDetails, object>() : null;
         var validationContext = new ValidationContext(target, serviceProvider: serviceProvider, items: null);
 
-        foreach (var property in typeProperties.Where(p => p.HasValidationAttributes || recurse))
+        foreach (var property in typeProperties)
         {
+            // Skip properties that don't have validation attributes if we're not recursing
+            if (!(property.HasValidationAttributes || recurse))
+            {
+                continue;
+            }
+
             var propertyValue = property.GetValue(target);
             var propertyValueType = propertyValue?.GetType();
             var (properties, _) = _typeDetailsCache.Get(propertyValueType);

--- a/tests/MiniValidation.UnitTests/Recursion.cs
+++ b/tests/MiniValidation.UnitTests/Recursion.cs
@@ -467,4 +467,30 @@ public class Recursion
         Assert.Single(errors);
         Assert.Equal($"{nameof(TestValidatableType.PocoChild)}.{nameof(TestAsyncValidatableChildType.TwentyOrMore)}", errors.Keys.First());
     }
+    
+    [Fact]
+    public async Task Throws_When_Validates_With_Recurse_And_Object_Has_Not_Implemented_Property()
+    {
+        var thingToValidate = new TestTypeWithNotImplementedProperty
+        {
+            PropertyToBeRequired = "test1"
+        };
+
+
+        await Assert.ThrowsAsync<Exception>(
+            async () => await MiniValidator.TryValidateAsync(thingToValidate, recurse: true));
+    }
+    
+    [Fact]
+    public async Task DoesntThrow_When_Validates_Without_Recurse_And_Object_Has_Not_Implemented_Property()
+    {
+        var thingToValidate = new TestTypeWithNotImplementedProperty
+        {
+            PropertyToBeRequired = "test1"
+        };
+
+        var (isValid, _) = await MiniValidator.TryValidateAsync(thingToValidate, recurse: false);
+
+        Assert.True(isValid);
+    }
 }

--- a/tests/MiniValidation.UnitTests/Recursion.cs
+++ b/tests/MiniValidation.UnitTests/Recursion.cs
@@ -477,8 +477,7 @@ public class Recursion
         };
 
 
-        await Assert.ThrowsAsync<Exception>(
-            async () => await MiniValidator.TryValidateAsync(thingToValidate, recurse: true));
+        await Assert.ThrowsAsync<Exception>(async () => await MiniValidator.TryValidateAsync(thingToValidate, recurse: true));
     }
     
     [Fact]

--- a/tests/MiniValidation.UnitTests/TestTypes.cs
+++ b/tests/MiniValidation.UnitTests/TestTypes.cs
@@ -259,6 +259,7 @@ class TestTypeForTypeDescriptor
     [MaxLength(1)]
     public string? AnotherProperty { get; set; } = "Test";
 }
+
 class TestTypeWithNotImplementedProperty
 {
     [Required]

--- a/tests/MiniValidation.UnitTests/TestTypes.cs
+++ b/tests/MiniValidation.UnitTests/TestTypes.cs
@@ -259,3 +259,10 @@ class TestTypeForTypeDescriptor
     [MaxLength(1)]
     public string? AnotherProperty { get; set; } = "Test";
 }
+class TestTypeWithNotImplementedProperty
+{
+    [Required]
+    public string? PropertyToBeRequired { get; set; }
+
+    public TestTypeForTypeDescriptor NotImplementedProperty => throw new Exception();
+}

--- a/tests/MiniValidation.UnitTests/TryValidate.cs
+++ b/tests/MiniValidation.UnitTests/TryValidate.cs
@@ -450,11 +450,11 @@ public class TryValidate
     [Fact]
     public async Task TryValidateAsync_With_Attribute_Attached_Via_TypeDescriptor()
     {
-        var thingToValidate = new TestTypeForTypeDescriptor();
-
         typeof(TestTypeForTypeDescriptor).AttachAttribute(
-            nameof(TestTypeForTypeDescriptor.PropertyToBeRequired), 
-            _ => new RequiredAttribute());
+                nameof(TestTypeForTypeDescriptor.PropertyToBeRequired),
+                _ => new RequiredAttribute());
+
+        var thingToValidate = new TestTypeForTypeDescriptor();
 
         var (isValid, errors) = await MiniValidator.TryValidateAsync(thingToValidate);
 


### PR DESCRIPTION
### Context
We have:
- `MiniValidator.TryValidateAsync` (or any other method) with `recurse` disabled
- Object that has a property without any validation attribute [example](https://github.com/Kraviecc/MiniValidation/blob/d618f6e001e37755e81cfb42c5e3047d60f0ecc9/tests/MiniValidation.UnitTests/TestTypes.cs#L262) and which can: 
  - Throw an exception (due to not implemented or temporal data inconsistency) from a property getter which is of a type that has at least one validation attribute
  - Trigger data (lazy) loading from a database that can lead, in specific scenarios, to deadlocks

For such a scenario, when we try to validate an instance of the class we get an exception (or data lazy loading) even though the engine shouldn't validate the problematic property - it doesn't have any validation attribute nor `recurse` is enabled.

### Solution
Filter out properties without any validation attribute only when the `recurse` is disabled.
